### PR TITLE
Refactor: Update custom property names in CSS

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -44,7 +44,7 @@ Author:  Phixyn
   --primary-link-color: rgb(219, 90, 127);
   --secondary-link-color: rgb(217, 147, 167);
   --primary-menu-link-color: rgb(157, 157, 157);
-  --secondary-menu-link-color: rgb(255, 255, 255);
+  --secondary-menu-link-color: rgb(234, 234, 234);
 }
 
 /* -----------------------------------


### PR DESCRIPTION
Updates the names of the custom properties used for colors in the
CSS file. This is to make the naming more consistent and also to
better describe the use of the properties. Some colors have also
been re-used where it made sense, and others removed.

This ensures that we're limiting the number of colors we're using
to a sensible number, instead of having a million different shades
of grey. It makes the style more consistent, and theming easier.
With these changes, there are at most 3 different colors for each
purpose (primary, secondary and accent).

Closes #29.