### PR TITLE
Feat: Form input validation

### DIFF
--- a/docs/devlog.md
+++ b/docs/devlog.md
@@ -1,7 +1,7 @@
 # No BS Looper Development Log
 
 ```
-Version: 1.0.0
+Version: 1.1.0
 Description: A no BS YouTube looper.
 Project start: 2 June 2020
 GitHub: https://github.com/Phixyn/no-bs-looper
@@ -45,6 +45,7 @@ Devlog template: 1.1.0
     - [Parsing YouTube Video URLs To Get ID](#parsing-youtube-video-urls-to-get-id)
     - [Simple websocket onerror handler](#simple-websocket-onerror-handler)
     - [querystring bla](#querystring-bla)
+    - [Foundation Abide plugin API](#foundation-abide-plugin-api)
 
 - - -
 
@@ -276,4 +277,15 @@ $.param(newState); // can also use Qs.stringify()
 // .replaceState might be less laggy
 history.replaceState(newState, "", "?" + $.param(newState));
 history.state;
+```
+
+### Foundation Abide plugin API
+
+```javascript
+// Add error classes to input field
+$("#form-id").foundation("addErrorClasses", $("#input-field-id"), ["pattern"]);
+$("#form-id").foundation("addErrorClasses", $("#input-field-id"), ["required"]);
+
+/// Remove all error classes from input field
+$("#form-id").foundation("removeErrorClasses", $("#input-field-id"));
 ```

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -2,7 +2,7 @@
 ZURB Foundation Phixed Dark Theme
 No BS edition.
 
-Version: 0.4.1 (no bs edition)
+Version: 0.4.2 (no bs edition)
 Author:  Phixyn
 ----------------------------------- */
 
@@ -299,6 +299,31 @@ li.is-submenu-item > a:hover {
 /* 'placeholder=' HTML attribute */
 ::placeholder {
   color: var(--primary-menu-link-color);
+}
+
+.help-text {
+  color: var(--primary-text-color);
+}
+
+/* Foundation Abide plugin error states */
+
+.is-invalid-label {
+
+}
+
+.is-invalid-input:not(:focus) {
+  /* background-color: var(--secondary-container-color); */
+  background-color: var(--accent-container-color);
+  /* color: var(--primary-menu-link-color); */
+}
+
+.is-invalid-input:not(:focus)::placeholder {
+  color: var(--primary-menu-link-color);
+}
+
+.is-invalid-input {
+  /* background-color: var(--secondary-container-color); */
+  /* background-color: var(--accent-container-color); */
 }
 
 /* -----------------------------------

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -307,23 +307,12 @@ li.is-submenu-item > a:hover {
 
 /* Foundation Abide plugin error states */
 
-.is-invalid-label {
-
-}
-
 .is-invalid-input:not(:focus) {
-  /* background-color: var(--secondary-container-color); */
   background-color: var(--accent-container-color);
-  /* color: var(--primary-menu-link-color); */
 }
 
 .is-invalid-input:not(:focus)::placeholder {
   color: var(--primary-menu-link-color);
-}
-
-.is-invalid-input {
-  /* background-color: var(--secondary-container-color); */
-  /* background-color: var(--accent-container-color); */
 }
 
 /* -----------------------------------

--- a/static/index.html
+++ b/static/index.html
@@ -62,41 +62,56 @@
         </div> <!-- .cell -->
       </div> <!-- .grid-x -->
 
-      <form class="grid-x grid-padding-x grid-padding-y">
+      <form id="video-form" class="grid-x grid-padding-x grid-padding-y" data-abide novalidate>
         <!-- Video ID -->
         <div class="cell small-12 medium-8 large-8 medium-offset-2 large-offset-2">
           <label>Video URL or ID
             <div class="input-group">
-              <input type="text" id="video-id" class="input-group-field" name="video-id" placeholder="Video ID" value="KcUnXunuDTs">
+              <input type="text" id="video-id" class="input-group-field" name="video-id" placeholder="Video ID" value="KcUnXunuDTs" aria-describedby="video-id-hint" aria-errormessage="video-id-error" required>
               <div class="input-group-button">
                 <input type="button" id="update-btn" class="button primary" name="update-btn" value="Update" onclick="updatePlayer()">
               </div>
             </div> <!-- .input-group -->
+            <span id="video-id-error" class="form-error" data-form-error-for="video-id" data-form-error-on="required">
+              Bruh. This box can't be empty. Type or paste in a valid YouTube link or video ID.
+            </span>
+            <span class="form-error" data-form-error-for="video-id" data-form-error-on="pattern">
+              This link didn't work :( Make sure it's a link to a video that starts with 'http://' or 'https://'
+            </span>
           </label>
+          <p class="help-text" id="video-id-hint">Paste a YouTube link or video ID here (e.g. https://www.youtube.com/watch?v=dQw4w9WgXcQ).</p>
         </div> <!-- .cell -->
 
         <!-- Start time -->
         <div class="cell small-6 medium-4 large-4 medium-offset-2 large-offset-2">
           <label>Start time (seconds)
             <div class="input-group">
-              <input type="number" id="start-time" class="input-group-field" name="start-time" placeholder="Start time (seconds)" value="0">
+              <input type="number" id="start-time" class="input-group-field" name="start-time" placeholder="Start time (seconds)" value="0" aria-describedby="start-time-hint" aria-errormessage="start-time-error" required pattern="number">
               <div class="input-group-button">
                 <input type="button" id="start-to-current-btn" class="button primary" name="start-to-current-btn" value="Current" onclick="setStartTimeToCurrent()">
               </div>
             </div> <!-- .input-group -->
+            <span id="start-time-error" class="form-error" data-form-error-for="start-time" data-form-error-on="required">
+              Bruh. You need to enter a valid start time. Numbers only, can't be empty.
+            </span>
           </label>
+          <p class="help-text" id="start-time-hint">The loop starts at this time.</p>
         </div> <!-- .cell -->
 
         <!-- End time -->
         <div class="cell small-6 medium-4 large-4">
           <label>End time (seconds)
             <div class="input-group">
-              <input type="number" id="end-time" class="input-group-field" name="end-time" placeholder="End time (seconds)" value="100" min="1">
+              <input type="number" id="end-time" class="input-group-field" name="end-time" placeholder="End time (seconds)" value="100" min="1" aria-describedby="end-time-hint" aria-errormessage="end-time-error" required pattern="number">
               <div class="input-group-button">
                 <input type="button" id="end-to-current-btn" class="button primary" name="end-to-current-btn" value="Current" onclick="setEndTimeToCurrent()">
               </div>
             </div> <!-- .input-group -->
+            <span id="end-time-error" class="form-error" data-form-error-for="end-time" data-form-error-on="required">
+              Bruh. You need to enter a valid end time. Numbers only, can't be empty.
+            </span>
           </label>
+          <p class="help-text" id="end-time-hint">The loop ends at this time.</p>
         </div> <!-- .cell -->
 
         <div class="cell medium-8 large-8 medium-offset-2 large-offset-2">

--- a/static/index.html
+++ b/static/index.html
@@ -67,13 +67,13 @@
         <div class="cell small-12 medium-8 large-8 medium-offset-2 large-offset-2">
           <label>Video link or ID
             <div class="input-group">
-              <input type="text" id="video-id" class="input-group-field" name="video-id" placeholder="Video ID" value="KcUnXunuDTs" aria-describedby="video-id-hint" aria-errormessage="video-id-error" required>
+              <input type="text" id="video-id" class="input-group-field" name="video-id" placeholder="Video link or ID" value="KcUnXunuDTs" aria-describedby="video-id-hint" aria-errormessage="video-id-error" required>
               <div class="input-group-button">
                 <input type="button" id="update-btn" class="button primary" name="update-btn" value="Update" onclick="updatePlayer()">
               </div>
             </div> <!-- .input-group -->
             <span id="video-id-error" class="form-error" data-form-error-for="video-id" data-form-error-on="required">
-              Bruh. This box can't be empty. Type or paste in a valid YouTube link or video ID.
+              This can't be empty. Type or paste in a valid YouTube link or video ID.
             </span>
             <span class="form-error" data-form-error-for="video-id" data-form-error-on="pattern">
               This link didn't work :( Make sure it's a link to a video that starts with 'http://' or 'https://'
@@ -92,10 +92,10 @@
               </div>
             </div> <!-- .input-group -->
             <span id="start-time-error" class="form-error" data-form-error-for="start-time">
-              Bruh. You need to enter a valid start time. Numbers only, can't be empty.
+              Invalid start time. Numbers only and can't be empty.
             </span>
           </label>
-          <p class="help-text" id="start-time-hint">The loop starts at this time.</p>
+          <p class="help-text" id="start-time-hint">Loop starts at this time.</p>
         </div> <!-- .cell -->
 
         <!-- End time -->
@@ -108,10 +108,10 @@
               </div>
             </div> <!-- .input-group -->
             <span id="end-time-error" class="form-error" data-form-error-for="end-time">
-              Bruh. You need to enter a valid end time. Numbers only, can't be empty.
+              Invalid end time. Numbers only and can't be empty.
             </span>
           </label>
-          <p class="help-text" id="end-time-hint">The loop ends at this time.</p>
+          <p class="help-text" id="end-time-hint">Loop ends (restarts) at this time.</p>
         </div> <!-- .cell -->
 
         <div class="cell medium-8 large-8 medium-offset-2 large-offset-2">

--- a/static/index.html
+++ b/static/index.html
@@ -91,7 +91,7 @@
                 <input type="button" id="start-to-current-btn" class="button primary" name="start-to-current-btn" value="Current" onclick="setStartTimeToCurrent()">
               </div>
             </div> <!-- .input-group -->
-            <span id="start-time-error" class="form-error" data-form-error-for="start-time" data-form-error-on="required">
+            <span id="start-time-error" class="form-error" data-form-error-for="start-time">
               Bruh. You need to enter a valid start time. Numbers only, can't be empty.
             </span>
           </label>
@@ -107,7 +107,7 @@
                 <input type="button" id="end-to-current-btn" class="button primary" name="end-to-current-btn" value="Current" onclick="setEndTimeToCurrent()">
               </div>
             </div> <!-- .input-group -->
-            <span id="end-time-error" class="form-error" data-form-error-for="end-time" data-form-error-on="required">
+            <span id="end-time-error" class="form-error" data-form-error-for="end-time">
               Bruh. You need to enter a valid end time. Numbers only, can't be empty.
             </span>
           </label>

--- a/static/index.html
+++ b/static/index.html
@@ -65,7 +65,7 @@
       <form id="video-form" class="grid-x grid-padding-x grid-padding-y" data-abide novalidate>
         <!-- Video ID -->
         <div class="cell small-12 medium-8 large-8 medium-offset-2 large-offset-2">
-          <label>Video URL or ID
+          <label>Video link or ID
             <div class="input-group">
               <input type="text" id="video-id" class="input-group-field" name="video-id" placeholder="Video ID" value="KcUnXunuDTs" aria-describedby="video-id-hint" aria-errormessage="video-id-error" required>
               <div class="input-group-button">

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -187,6 +187,11 @@ function onPlayerReady(event) {
 
   // Fired when one of the slider's handles is moved
   $(sliderDiv).on("moved.zf.slider", () => {
+    // Foundation Abide plugin validation. Needs to be manually called on slider
+    // change, for all of its bound input elements.
+    videoForm.foundation("validateInput", startTimeInput);
+    videoForm.foundation("validateInput", endTimeInput);
+
     updateLoopPortion();
   });
 
@@ -365,12 +370,6 @@ function togglePlayer() {
  */
 function updateLoopPortion() {
   console.debug("[DEBUG] Setting new loop start and end times (state change)");
-
-  // Foundation Abide plugin validation. Needs to be manually called on slider
-  // change, for all of its bound input elements.
-  // TODO consider moving to the slider moved handler
-  videoForm.foundation("validateInput", startTimeInput);
-  videoForm.foundation("validateInput", endTimeInput);
 
   let startTime = parseInt(startTimeInput.val(), 10);
   let endTime = parseInt(endTimeInput.val(), 10);

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -296,7 +296,7 @@ function updatePlayer() {
     let videoId = extractVideoId(videoIdInputVal);
 
     if (videoId === null) {
-      // TODO #75: Show error toast to the user.
+      // TODO #75: Show error toast to the user
       videoForm.foundation("addErrorClasses", videoIdInput, ["pattern"]);
       console.error(
         `[ERROR] Invalid video URL or ID in input: '${videoIdInputVal}'.`
@@ -308,7 +308,7 @@ function updatePlayer() {
   } else if (videoIdInputVal.length === VIDEO_ID_LENGTH) {
     state.v = videoIdInputVal;
   } else {
-    // TODO #75: Show error toast to the user.
+    // TODO #75: Show error toast to the user
     videoForm.foundation("addErrorClasses", videoIdInput, ["pattern"]);
     console.error(
       `[ERROR] Invalid video URL or ID in input: '${videoIdInputVal}'.`

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -374,35 +374,13 @@ function updateLoopPortion() {
   let startTime = parseInt(startTimeInput.val(), 10);
   let endTime = parseInt(endTimeInput.val(), 10);
 
-  // TODO: causes state to only be updated if BOTH inputs are numbers.
-  // Might not be desired, so consider refactoring/improving logic?
-  // if (isNaN(startTime) || isNaN(endTime)) {
-  //   console.error(
-  //     "[ERROR] Invalid start or end time. Not updating loop and state."
-  //   );
-  //   return;
-  // }
-
   if (!isNaN(startTime) && startTime != state.start) {
-    console.debug("[DEBUG] New start time detected.");
     state.start = startTime;
   }
 
   if (!isNaN(endTime) && endTime != state.end) {
-    console.debug("[DEBUG] New end time detected.");
     state.end = endTime;
   }
-
-  // TODO ternary/conditional assignment
-  // if (startTime != state.start) {
-  //   console.debug("[DEBUG] New start time detected.");
-  //   state.start = startTime;
-  // }
-
-  // if (endTime != state.end) {
-  //   console.debug("[DEBUG] New end time detected.");
-  //   state.end = endTime;
-  // }
 
   // If needed, seek to the desired start time for the loop portion
   if (
@@ -585,7 +563,6 @@ function extractVideoId(youtubeUrl) {
     }
 
     videoId = qsParse.v;
-    console.debug(`[DEBUG] Got video ID from querystring: '${videoId}'.`);
   } else if (urlObj.pathname !== "") {
     console.log("[INFO] Extracting potential video ID from URL pathname.");
     // Handle 'youtu.be/id' and 'youtube.com/embed/id'

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -369,8 +369,6 @@ function togglePlayer() {
  * Note: The slider and input elements are data bound.
  */
 function updateLoopPortion() {
-  console.debug("[DEBUG] Setting new loop start and end times (state change)");
-
   let startTime = parseInt(startTimeInput.val(), 10);
   let endTime = parseInt(endTimeInput.val(), 10);
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -31,7 +31,7 @@ websocket.onmessage = (event) => {
   let msg = JSON.parse(event.data);
   // TODO #46: Check message payload in client's onmessage handler
   // We got a new video duration, so update the slider and input elements
-  state.end = parseInt(msg.length_seconds);
+  state.end = parseInt(msg.length_seconds, 10);
   updateSliderAndInputAttributes(state.start, state.end);
 
   // TODO #52: Workaround for slider fill bug
@@ -104,10 +104,11 @@ $(() => {
     console.debug("[DEBUG] Qs parsed querystring to object:");
     console.debug(qsParse);
 
+    // TODO #59: Handle broken querystrings in URL
     state = {
       v: qsParse.v,
-      start: parseInt(qsParse.start),
-      end: parseInt(qsParse.end),
+      start: parseInt(qsParse.start, 10),
+      end: parseInt(qsParse.end, 10),
     };
     console.debug("[DEBUG] State object set using querystring. Current state:");
     console.debug(state);
@@ -128,8 +129,8 @@ $(() => {
     // Get state data from HTML form (i.e. default values)
     state = {
       v: videoIdInput.val(),
-      start: parseInt(startTimeInput.val()),
-      end: parseInt(endTimeInput.val()),
+      start: parseInt(startTimeInput.val(), 10),
+      end: parseInt(endTimeInput.val(), 10),
     };
     updateHistoryState();
   }
@@ -210,7 +211,7 @@ function onPlayerReady(event) {
 
   updateSliderAndInputAttributes(
     state.start,
-    parseInt(event.target.getDuration())
+    parseInt(event.target.getDuration(), 10)
   );
 
   // TODO #54: This shouldn't be needed because it's already set in
@@ -436,7 +437,7 @@ function updateHistoryState() {
  * Sets the loop portion's start time to the current time of the video.
  */
 function setStartTimeToCurrent() {
-  state.start = parseInt(player.getCurrentTime());
+  state.start = parseInt(player.getCurrentTime(), 10);
   startTimeInput.val(state.start.toString()).change();
 }
 
@@ -444,7 +445,7 @@ function setStartTimeToCurrent() {
  * Sets the loop portion's end time to the current time of the video.
  */
 function setEndTimeToCurrent() {
-  state.end = parseInt(player.getCurrentTime());
+  state.end = parseInt(player.getCurrentTime(), 10);
   endTimeInput.val(state.end.toString()).change();
 }
 


### PR DESCRIPTION
# Pull Request Submission

Thank you for taking the time to contribute to this project! Please take the time to tell us a bit about the changes you've made.

## Description

> Give a short and brief description of the pull request. Add a screenshot if appropriate and helpful. Changes can be listed in the next section.

Adds validation to the HTML form inputs. Errors are now displayed when users try to enter and submit invalid data.

Previews:

![1](https://user-images.githubusercontent.com/9574132/97200045-a4195400-17a8-11eb-8332-3bc52dfb1134.png)

![2](https://user-images.githubusercontent.com/9574132/97200051-a54a8100-17a8-11eb-9e20-772007eaf6a5.png)

- - -

Closes #38.

## Changes

> List the changes made.

- Added Abide plugin integration into the HTML form
- Added help messages below each input field
- Added error messages to each input field. These are displayed by the Abide plugin and API
- Added CSS for input error states and help messages
- Updated client to validate numeric input fields on slider movement
- Updated client to validate start and end time values on `updateLoopPortion()`
- Updated label for video link/ID input
- Updated placeholder string for video link/ID input
- Fixed an issue wherein start and end time values could potentially be parsed into octal values (1c61c29)
- Removed some debug logging that was no longer useful in debugging

## Breaking Change?

> Will these changes cause existing functionality to not work as expected? Will contributors be able to run the project after these changes are merged, without needing to take any additional steps?

- [ ] Please tick if this is a breaking change and **describe why** below

## Merging Checklist

> Lastly, before merging we need to make sure that these are done.

- [x] Project builds and runs
- [x] All changes were tested
- ~~All tests are up-to-date~~ - N/A
- ~~All tests pass~~ - N/A
- [x] Code style follows current [style guide](https://google.github.io/styleguide/jsguide.html)
- [x] Code documentation is up-to-date
- [x] Project documentation is up-to-date