### PR TITLE
Fix end time input and slider being stuck at 1 second

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -71,18 +71,16 @@ websocket.onmessage = (event) => {
       break;
     case TYPE_VIDEO_INFO_MESSAGE:
       // We got a new video duration, so update the slider and input elements
-      state.videoDuration = parseInt(msg.content.length_seconds, 10);
-      // state.end = state.videoDuration;
-      // Clamp state.end to videoDuration
-      if (!isInitialVideo || state.end > state.videoDuration) {
-        state.end = state.videoDuration;
+      let videoDuration = parseInt(msg.content.length_seconds, 10);
+      // Preserve state.end value if this is the initial video's duration
+      if (!isInitialVideo) {
+        state.end = videoDuration;
       }
 
-      console.debug("STATE FROM ONMESSAGE IS");
-      console.debug(state);
-      // TODO try state.end and remove videoDuration
-      updateSliderAndInputAttributes(state.start, state.videoDuration);
+      updateSliderAndInputAttributes(state.start, videoDuration);
 
+      // TODO #54: This shouldn't be needed because it's already set in
+      //    updateSliderAndInputAttributes(). But the slider breaks without it.
       console.debug(
         "[DEBUG] Setting numeric input fields from websocket onmessage."
       );

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -231,9 +231,6 @@ $(function () {
     };
     console.debug("[DEBUG] State object set using querystring. Current state:");
     console.debug(state);
-    // Do this just in case history.state doesn't get automatically set
-    // from the URL's querystring. Same applies to the call below.
-    updateHistoryState();
 
     /* Update text input for video ID (remember we can't update numeric inputs
      * here yet, because we need to set the "max" attributes. We can only set
@@ -251,8 +248,11 @@ $(function () {
       start: parseInt(startTimeInput.val(), 10),
       end: parseInt(endTimeInput.val(), 10),
     };
-    updateHistoryState();
   }
+
+  // Do this just in case history.state doesn't get automatically set
+  // from the URL's querystring.
+  updateHistoryState();
 });
 
 // YouTube Player event handlers

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -80,7 +80,8 @@ websocket.onmessage = (event) => {
       updateSliderAndInputAttributes(state.start, videoDuration);
 
       // TODO #54: This shouldn't be needed because it's already set in
-      //    updateSliderAndInputAttributes(). But the slider breaks without it.
+      //    updateSliderAndInputAttributes(). But startTime value is wrong on
+      //    initial video without it...
       console.debug(
         "[DEBUG] Setting numeric input fields from websocket onmessage."
       );
@@ -321,18 +322,18 @@ function onPlayerReady(event) {
    */
   $(sliderDiv).on("changed.zf.slider", () => {
     /* Only update state (used to set the querystring portion of the URL) after
-     * the start/end times haven't been updated for 2000ms. The idea is to
+     * the start/end times haven't been updated for 500ms. The idea is to
      * reduce lag and overhead when updating the state. Updating the state
-     * everytime the slider is moved causes massive lag. Updating it every
-     * 500ms is slightly better, but can be laggy if a browser is already under
-     * heavy load (e.g. many tabs loaded). 2000 to 5000ms seems like a good
-     * value, but larger values could leave users confused as to why the
-     * sharable URL they copied (which is set based on state) is wrong if they
-     * copy it too fast after moving the slider.
+     * everytime the slider is moved causes massive lag. Updating it 500ms
+     * after the user finished moving the slider is better. Values between
+     * 500-2000ms seem good - larger values could leave users confused as to
+     * why the sharable URL they copied (which is set based on state) is wrong
+     * if they copy it too fast after moving the slider.
      */
     updateHistoryState();
   });
 
+  // Request video duration and other info from backend server
   websocket.send(JSON.stringify({ get_video_info: state.v }));
 
   // TODO #54: This shouldn't be needed because it's already set in

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -86,7 +86,6 @@ websocket.onmessage = (event) => {
         "[DEBUG] Setting numeric input fields from websocket onmessage."
       );
       startTimeInput.val(state.start.toString()).change();
-      endTimeInput.val(state.end.toString()).change();
 
       // TODO #52: Workaround for slider fill bug
       setTimeout(() => {
@@ -335,17 +334,6 @@ function onPlayerReady(event) {
 
   // Request video duration and other info from backend server
   websocket.send(JSON.stringify({ get_video_info: state.v }));
-
-  // TODO #54: This shouldn't be needed because it's already set in
-  //    updateSliderAndInputAttributes(). But the slider breaks without it.
-  // console.debug("[DEBUG] Setting numeric input fields from YT onPlayerReady.");
-  // startTimeInput.val(state.start.toString()).change();
-  // endTimeInput.val(state.end.toString()).change();
-
-  // TODO #52: Workaround for slider fill bug
-  setTimeout(() => {
-    loopPortionSlider._reflow();
-  }, TIMEOUT_SLIDER_REFLOW);
 }
 
 var timer = null;


### PR DESCRIPTION
# Pull Request Submission

## Description

> Give a short and brief description of the pull request. Add a screenshot if appropriate and helpful. Changes can be listed in the next section.

Fixes an issue wherein the value of the "End time" input field could get stuck at 1 second along with the slider. The issue was due to a race condition caused by a call to the YouTube IFrame API. A call to `player.getDuration()` would often return 0. This value would then be used to set the input fields' max value attributes, and the slider's logical and visual end values. As a result, users could not set anything values for start or end past 1 second.

Closes #112.

## Changes

> List the changes made.

- Removed call to `player.videoGetDuration()` in `onPlayerReady` handler
- Added a call to `websocket.send` to request video info in `onPlayerReady` handler
- Moved call to `updateSliderAndInputAttributes` and workaround for #54 to websocket's `onmessage` handler
- Updated websocket's `onmessage` handler to take into account initial video and preserve the value of `state.end` when needed
- Updated some code comments

## Breaking Change?

> Will these changes cause existing functionality to not work as expected? Will contributors be able to run the project after these changes are merged, without needing to take any additional steps?

Not a breaking change.

## Merging Checklist

> Lastly, before merging we need to make sure that these are done.

- [x] Project builds and runs
- [x] All changes were tested
- [x] Code style follows current [style guide](https://google.github.io/styleguide/jsguide.html)
- [x] Code documentation is up-to-date
- [x] Project documentation is up-to-date