### PR TITLE
Fix 'Update' button not working when used for the first time

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -280,7 +280,6 @@ function onYouTubeIframeAPIReady() {
       rel: 0,
       start: state.start,
       modestBranding: 1,
-      playlist: state.v,
       loop: 1,
     },
     events: {
@@ -341,6 +340,12 @@ function onPlayerReady(event) {
 
   // Request video duration and other info from backend server
   websocket.send(JSON.stringify({ get_video_info: state.v }));
+  /* Using a playlist is required to ensure that full videos loop without
+   * stopping. See comment above player.loadPlaylist() in updatePlayer()
+   * for more information.
+   */
+  player.cuePlaylist([state.v, state.v]);
+  player.setLoop(true);
 }
 
 var timer = null;
@@ -439,8 +444,8 @@ function updatePlayer() {
   console.log(`[INFO] Loading new video in player with ID '${state.v}'.`);
   /* loadPlaylist() and setLoop() are required to make infinite loops of full
    * videos (i.e. not portions of a video). It's for this same reason that we
-   * set 'playlist' and 'loop' in the 'playerVars' (see
-   * onYouTubeIframeAPIReady()).
+   * set 'loop: 1' in the 'playerVars' and call 'cuePlaylist()' (see
+   * onYouTubeIframeAPIReady() and onPlayerReady()) when setting up the player.
    *
    * Normally, we'd use player.loadVideoById(state.v), but then the video
    * wouldn't loop unless users explicitly set a loop portion using the slider.


### PR DESCRIPTION
# Pull Request Submission

Thank you for taking the time to contribute to this project! Please take the time to tell us a bit about the changes you've made.

## Description

> Give a short and brief description of the pull request. Add a screenshot if appropriate and helpful. Changes can be listed in the next section.

Fixes an issue wherein the video player would not load a new video after the 'Update' button was clicked or tapped. This would only happen the first time that users would click/tap the 'Update' button.

Closes #111.

## Changes

> List the changes made.

- Removed `playlist` property from `playerVars` when initializing `YT.Player`
- Added a call to `player.cuePlaylist()` in the `onPlayerReady` event handler to cue the first playlist

## Breaking Change?

> Will these changes cause existing functionality to not work as expected? Will contributors be able to run the project after these changes are merged, without needing to take any additional steps?

Not a breaking change.

## Merging Checklist

> Lastly, before merging we need to make sure that these are done.

- [x] Project builds and runs
- [x] All changes were tested
- [x] Code style follows current [style guide](https://google.github.io/styleguide/jsguide.html)
- [x] Code documentation is up-to-date
- [x] Project documentation is up-to-date