### PR TITLE
Remove title attribute from links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
     <img src="https://img.shields.io/badge/license-GPLv3-blue.svg" alt="GPLv3 badge" />
   </a>
 
-  <a href="http://ytlooper.phixyn.com/" title="Website">Website</a> • <a href="https://github.com/Phixyn/no-bs-looper/issues">Issue Tracker</a> • <a href="https://github.com/Phixyn/no-bs-looper/releases">Releases</a> • <a href="https://github.com/Phixyn/no-bs-looper/blob/master/.github/CONTRIBUTING.md" title="Contributing">Contributing</a>
+  <a href="http://ytlooper.phixyn.com/">Website</a> • <a href="https://github.com/Phixyn/no-bs-looper/issues">Issue Tracker</a> • <a href="https://github.com/Phixyn/no-bs-looper/releases">Releases</a> • <a href="https://github.com/Phixyn/no-bs-looper/blob/master/.github/CONTRIBUTING.md">Contributing</a>
 
   ![Preview Screenshot](docs/screenshots/desktop_demo_yt_controls.png?raw=true)
 </div>


### PR DESCRIPTION
## Description

Removes `title` attribute from links in the README header.  
They were annoying me, everytime I hover over the links...