### PR TITLE
Parse "si" YouTube links

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -748,7 +748,7 @@ function extractVideoId(youtubeUrl) {
   }
 
   // Check if there is a querystring in the URL and parse it
-  if (urlObj.search !== "") {
+  if (urlObj.search !== "" && urlObj.search.includes("si=") !== true) {
     console.log("[INFO] Found querystring in URL, parsing it.");
 
     let qsParse = Qs.parse(urlObj.search, { ignoreQueryPrefix: true });


### PR DESCRIPTION
## Description

This is an old hotfix that's already deployed (I hope xD).

Extracts video ID from links that have the "si" query parameter.  
Previously, these links would be ignored, now they work.